### PR TITLE
Adding ability to attach the Kibana Discover url

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -1781,6 +1781,12 @@ Provide absolute address of the pciture, for example: http://some.address.com/im
 
 ``slack_timeout``: You can specify a timeout value, in seconds, for making communicating with Slac. The default is 10. If a timeout occurs, the alert will be retried next time elastalert cycles.
 
+``slack_attach_kibana_discover_url``: Enables the attachment of the ``kibana_discover_url`` to the slack notification. The config ``generate_kibana_discover_url`` must also be ``True`` in order to generate the url. Defaults to ``False``.
+
+``slack_kibana_discover_color``: The color of the Kibana Discover url attachment. Defaults to ``#ec4b98``.
+
+``slack_kibana_discover_title``: The title of the Kibana Discover url attachment. Defaults to ``Discover in Kibana``.
+
 Mattermost
 ~~~~~~~~~~
 

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -1129,6 +1129,9 @@ class SlackAlerter(Alerter):
         self.slack_ignore_ssl_errors = self.rule.get('slack_ignore_ssl_errors', False)
         self.slack_timeout = self.rule.get('slack_timeout', 10)
         self.slack_ca_certs = self.rule.get('slack_ca_certs')
+        self.slack_attach_kibana_discover_url = self.rule.get('slack_attach_kibana_discover_url', False)
+        self.slack_kibana_discover_color = self.rule.get('slack_kibana_discover_color', '#ec4b98')
+        self.slack_kibana_discover_title = self.rule.get('slack_kibana_discover_title', 'Discover in Kibana')
 
     def format_body(self, body):
         # https://api.slack.com/docs/formatting
@@ -1190,6 +1193,15 @@ class SlackAlerter(Alerter):
 
         if self.slack_title_link != '':
             payload['attachments'][0]['title_link'] = self.slack_title_link
+
+        if self.slack_attach_kibana_discover_url:
+            kibana_discover_url = lookup_es_key(matches[0], 'kibana_discover_url')
+            if kibana_discover_url:
+                payload['attachments'].append({
+                    'color': self.slack_kibana_discover_color,
+                    'title': self.slack_kibana_discover_title,
+                    'title_link': kibana_discover_url
+                })
 
         for url in self.slack_webhook_url:
             for channel_override in self.slack_channel_override:

--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -286,6 +286,9 @@ properties:
   slack_text_string: {type: string}
   slack_ignore_ssl_errors: {type: boolean}
   slack_ca_certs: {type: string}
+  slack_attach_kibana_discover_url {type: boolean}
+  slack_kibana_discover_color {type: string}
+  slack_kibana_discover_title {type: string}
 
   ### Mattermost
   mattermost_webhook_url: *arrayOfString

--- a/tests/alerts_test.py
+++ b/tests/alerts_test.py
@@ -1190,6 +1190,206 @@ def test_slack_uses_list_of_custom_slack_channel():
     assert expected_data2 == json.loads(mock_post_request.call_args_list[1][1]['data'])
 
 
+def test_slack_attach_kibana_discover_url_when_generated():
+    rule = {
+        'name': 'Test Rule',
+        'type': 'any',
+        'slack_attach_kibana_discover_url': True,
+        'slack_webhook_url': 'http://please.dontgohere.slack',
+        'alert': []
+    }
+    rules_loader = FileRulesLoader({})
+    rules_loader.load_modules(rule)
+    alert = SlackAlerter(rule)
+    match = {
+        '@timestamp': '2016-01-01T00:00:00',
+        'kibana_discover_url': 'http://kibana#discover'
+    }
+    with mock.patch('requests.post') as mock_post_request:
+        alert.alert([match])
+
+    expected_data = {
+        'username': 'elastalert',
+        'parse': 'none',
+        'text': '',
+        'attachments': [
+            {
+                'color': 'danger',
+                'title': 'Test Rule',
+                'text': BasicMatchString(rule, match).__str__(),
+                'mrkdwn_in': ['text', 'pretext'],
+                'fields': []
+            },
+            {
+                'color': '#ec4b98',
+                'title': 'Discover in Kibana',
+                'title_link': 'http://kibana#discover'
+            }
+        ],
+        'icon_emoji': ':ghost:',
+        'channel': ''
+    }
+    mock_post_request.assert_called_once_with(
+        rule['slack_webhook_url'],
+        data=mock.ANY,
+        headers={'content-type': 'application/json'},
+        proxies=None,
+        verify=False,
+        timeout=10
+    )
+    actual_data = json.loads(mock_post_request.call_args_list[0][1]['data'])
+    assert expected_data == actual_data
+
+
+def test_slack_attach_kibana_discover_url_when_not_generated():
+    rule = {
+        'name': 'Test Rule',
+        'type': 'any',
+        'slack_attach_kibana_discover_url': True,
+        'slack_webhook_url': 'http://please.dontgohere.slack',
+        'alert': []
+    }
+    rules_loader = FileRulesLoader({})
+    rules_loader.load_modules(rule)
+    alert = SlackAlerter(rule)
+    match = {
+        '@timestamp': '2016-01-01T00:00:00'
+    }
+    with mock.patch('requests.post') as mock_post_request:
+        alert.alert([match])
+
+    expected_data = {
+        'username': 'elastalert',
+        'parse': 'none',
+        'text': '',
+        'attachments': [
+            {
+                'color': 'danger',
+                'title': 'Test Rule',
+                'text': BasicMatchString(rule, match).__str__(),
+                'mrkdwn_in': ['text', 'pretext'],
+                'fields': []
+            }
+        ],
+        'icon_emoji': ':ghost:',
+        'channel': ''
+    }
+    mock_post_request.assert_called_once_with(
+        rule['slack_webhook_url'],
+        data=mock.ANY,
+        headers={'content-type': 'application/json'},
+        proxies=None,
+        verify=False,
+        timeout=10
+    )
+    actual_data = json.loads(mock_post_request.call_args_list[0][1]['data'])
+    assert expected_data == actual_data
+
+
+def test_slack_kibana_discover_title():
+    rule = {
+        'name': 'Test Rule',
+        'type': 'any',
+        'slack_attach_kibana_discover_url': True,
+        'slack_kibana_discover_title': 'Click to discover in Kibana',
+        'slack_webhook_url': 'http://please.dontgohere.slack',
+        'alert': []
+    }
+    rules_loader = FileRulesLoader({})
+    rules_loader.load_modules(rule)
+    alert = SlackAlerter(rule)
+    match = {
+        '@timestamp': '2016-01-01T00:00:00',
+        'kibana_discover_url': 'http://kibana#discover'
+    }
+    with mock.patch('requests.post') as mock_post_request:
+        alert.alert([match])
+
+    expected_data = {
+        'username': 'elastalert',
+        'parse': 'none',
+        'text': '',
+        'attachments': [
+            {
+                'color': 'danger',
+                'title': 'Test Rule',
+                'text': BasicMatchString(rule, match).__str__(),
+                'mrkdwn_in': ['text', 'pretext'],
+                'fields': []
+            },
+            {
+                'color': '#ec4b98',
+                'title': 'Click to discover in Kibana',
+                'title_link': 'http://kibana#discover'
+            }
+        ],
+        'icon_emoji': ':ghost:',
+        'channel': ''
+    }
+    mock_post_request.assert_called_once_with(
+        rule['slack_webhook_url'],
+        data=mock.ANY,
+        headers={'content-type': 'application/json'},
+        proxies=None,
+        verify=False,
+        timeout=10
+    )
+    actual_data = json.loads(mock_post_request.call_args_list[0][1]['data'])
+    assert expected_data == actual_data
+
+
+def test_slack_kibana_discover_color():
+    rule = {
+        'name': 'Test Rule',
+        'type': 'any',
+        'slack_attach_kibana_discover_url': True,
+        'slack_kibana_discover_color': 'blue',
+        'slack_webhook_url': 'http://please.dontgohere.slack',
+        'alert': []
+    }
+    rules_loader = FileRulesLoader({})
+    rules_loader.load_modules(rule)
+    alert = SlackAlerter(rule)
+    match = {
+        '@timestamp': '2016-01-01T00:00:00',
+        'kibana_discover_url': 'http://kibana#discover'
+    }
+    with mock.patch('requests.post') as mock_post_request:
+        alert.alert([match])
+
+    expected_data = {
+        'username': 'elastalert',
+        'parse': 'none',
+        'text': '',
+        'attachments': [
+            {
+                'color': 'danger',
+                'title': 'Test Rule',
+                'text': BasicMatchString(rule, match).__str__(),
+                'mrkdwn_in': ['text', 'pretext'],
+                'fields': []
+            },
+            {
+                'color': 'blue',
+                'title': 'Discover in Kibana',
+                'title_link': 'http://kibana#discover'
+            }
+        ],
+        'icon_emoji': ':ghost:',
+        'channel': ''
+    }
+    mock_post_request.assert_called_once_with(
+        rule['slack_webhook_url'],
+        data=mock.ANY,
+        headers={'content-type': 'application/json'},
+        proxies=None,
+        verify=False,
+        timeout=10
+    )
+    actual_data = json.loads(mock_post_request.call_args_list[0][1]['data'])
+    assert expected_data == actual_data
+
+
 def test_http_alerter_with_payload():
     rule = {
         'name': 'Test HTTP Post Alerter With Payload',


### PR DESCRIPTION
Adding ability to attach the Kibana Discover url as a separate attachment in Slack notifications:

Kibana Link remains in focus for large bodies:

![image](https://user-images.githubusercontent.com/12101120/65633710-b83dc100-dfaa-11e9-88e9-37900cc6409f.png)

Link to Kibana remains in a consistent location, regardless of alert text formatting.

Simple config:

```
slack_attach_kibana_discover_url: True
```